### PR TITLE
FIx URL join in windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,4 @@ smart_contracts/
 .DS_Store
 
 .ruff_cache/
+cairo_model/

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 ---
-description: Giza CLI 0.9.0
+description: Giza CLI 0.9.1
 ---
 
 # Giza CLI

--- a/docs/examples/full_transpilation.md
+++ b/docs/examples/full_transpilation.md
@@ -21,7 +21,7 @@ pip install -r requirements.txt
 Or:
 
 ```bash
-pip install giza-cli==0.9.0 onnx==1.14.1 torch==2.1.0 torchvision==0.16.0
+pip install giza-cli==0.9.1 onnx==1.14.1 torch==2.1.0 torchvision==0.16.0
 ```
 
 We will use the libraries for the following purposes:

--- a/examples/mnist/mnist_pytorch.ipynb
+++ b/examples/mnist/mnist_pytorch.ipynb
@@ -41,7 +41,7 @@
     "Or:\n",
     "\n",
     "```bash\n",
-    "pip install giza-cli==0.9.0 onnx==1.14.1 torch==2.1.0 torchvision==0.16.0\n",
+    "pip install giza-cli==0.9.1 onnx==1.14.1 torch==2.1.0 torchvision==0.16.0\n",
     "```\n",
     "\n",
     "We will use the libraries for the following purposes:\n",

--- a/examples/mnist/requirements.txt
+++ b/examples/mnist/requirements.txt
@@ -1,4 +1,4 @@
-giza-cli==0.9.0
+giza-cli==0.9.1
 onnx==1.14.1
 tf2onnx==1.15.1
 torch==2.1.0

--- a/giza/__init__.py
+++ b/giza/__init__.py
@@ -1,5 +1,5 @@
 import os
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"
 # Until DNS is fixed
 API_HOST = os.environ.get("GIZA_API_HOST", "https://api.gizatech.xyz")

--- a/giza/client.py
+++ b/giza/client.py
@@ -464,13 +464,15 @@ class DeploymentsClient(ApiClient):
         headers.update(self._get_auth_header())
 
         response = self.session.post(
-            os.path.join(
-                self.url,
-                self.MODELS_ENDPOINT,
-                str(model_id),
-                self.VERSIONS_ENDPOINT,
-                str(version_id),
-                self.DEPLOYMENTS_ENDPOINT,
+            "/".join(
+                [
+                    self.url,
+                    self.MODELS_ENDPOINT,
+                    str(model_id),
+                    self.VERSIONS_ENDPOINT,
+                    str(version_id),
+                    self.DEPLOYMENTS_ENDPOINT,
+                ]
             ),
             headers=headers,
             params=deployment_create.dict(),
@@ -494,13 +496,15 @@ class DeploymentsClient(ApiClient):
         headers.update(self._get_auth_header())
 
         response = self.session.get(
-            os.path.join(
-                self.url,
-                self.MODELS_ENDPOINT,
-                str(model_id),
-                self.VERSIONS_ENDPOINT,
-                str(version_id),
-                self.DEPLOYMENTS_ENDPOINT,
+            "/".join(
+                [
+                    self.url,
+                    self.MODELS_ENDPOINT,
+                    str(model_id),
+                    self.VERSIONS_ENDPOINT,
+                    str(version_id),
+                    self.DEPLOYMENTS_ENDPOINT,
+                ]
             ),
             headers=headers,
         )
@@ -526,15 +530,17 @@ class DeploymentsClient(ApiClient):
         headers.update(self._get_auth_header())
 
         response = self.session.get(
-            os.path.join(
-                self.url,
-                self.MODELS_ENDPOINT,
-                str(model_id),
-                self.VERSIONS_ENDPOINT,
-                str(version_id),
-                self.DEPLOYMENTS_ENDPOINT,
-                str(deployment_id),
-                "proofs",
+            "/".join(
+                [
+                    self.url,
+                    self.MODELS_ENDPOINT,
+                    str(model_id),
+                    self.VERSIONS_ENDPOINT,
+                    str(version_id),
+                    self.DEPLOYMENTS_ENDPOINT,
+                    str(deployment_id),
+                    "proofs",
+                ]
             ),
             headers=headers,
         )
@@ -559,16 +565,18 @@ class DeploymentsClient(ApiClient):
         headers.update(self._get_auth_header())
 
         response = self.session.get(
-            os.path.join(
-                self.url,
-                self.MODELS_ENDPOINT,
-                str(model_id),
-                self.VERSIONS_ENDPOINT,
-                str(version_id),
-                self.DEPLOYMENTS_ENDPOINT,
-                str(deployment_id),
-                "proofs",
-                str(proof_id),
+            "/".join(
+                [
+                    self.url,
+                    self.MODELS_ENDPOINT,
+                    str(model_id),
+                    self.VERSIONS_ENDPOINT,
+                    str(version_id),
+                    self.DEPLOYMENTS_ENDPOINT,
+                    str(deployment_id),
+                    "proofs",
+                    str(proof_id),
+                ]
             ),
             headers=headers,
         )
@@ -595,16 +603,18 @@ class DeploymentsClient(ApiClient):
         headers.update(self._get_auth_header())
 
         response = self.session.get(
-            os.path.join(
-                self.url,
-                self.MODELS_ENDPOINT,
-                str(model_id),
-                self.VERSIONS_ENDPOINT,
-                str(version_id),
-                self.DEPLOYMENTS_ENDPOINT,
-                str(deployment_id),
-                "proofs",
-                f"{proof_id}:download",
+            "/".join(
+                [
+                    self.url,
+                    self.MODELS_ENDPOINT,
+                    str(model_id),
+                    self.VERSIONS_ENDPOINT,
+                    str(version_id),
+                    self.DEPLOYMENTS_ENDPOINT,
+                    str(deployment_id),
+                    "proofs",
+                    f"{proof_id}:download",
+                ]
             ),
             headers=headers,
         )
@@ -636,14 +646,16 @@ class DeploymentsClient(ApiClient):
         headers.update(self._get_auth_header())
 
         response = self.session.get(
-            os.path.join(
-                self.url,
-                self.MODELS_ENDPOINT,
-                str(model_id),
-                self.VERSIONS_ENDPOINT,
-                str(version_id),
-                self.DEPLOYMENTS_ENDPOINT,
-                str(deployment_id),
+            "/".join(
+                [
+                    self.url,
+                    self.MODELS_ENDPOINT,
+                    str(model_id),
+                    self.VERSIONS_ENDPOINT,
+                    str(version_id),
+                    self.DEPLOYMENTS_ENDPOINT,
+                    str(deployment_id),
+                ]
             ),
             headers=headers,
         )
@@ -928,14 +940,16 @@ class VersionJobsClient(ApiClient):
         headers.update(self._get_auth_header())
 
         response = self.session.get(
-            os.path.join(
-                self.url,
-                self.MODELS_ENDPOINT,
-                str(model_id),
-                self.VERSIONS_ENDPOINT,
-                str(version_id),
-                self.JOBS_ENDPOINT,
-                str(job_id),
+            "/".join(
+                [
+                    self.url,
+                    self.MODELS_ENDPOINT,
+                    str(model_id),
+                    self.VERSIONS_ENDPOINT,
+                    str(version_id),
+                    self.JOBS_ENDPOINT,
+                    str(job_id),
+                ]
             ),
             headers=headers,
         )
@@ -965,13 +979,15 @@ class VersionJobsClient(ApiClient):
         headers = copy.deepcopy(self.default_headers)
         headers.update(self._get_auth_header())
         response = self.session.post(
-            os.path.join(
-                self.url,
-                self.MODELS_ENDPOINT,
-                str(model_id),
-                self.VERSIONS_ENDPOINT,
-                str(version_id),
-                self.JOBS_ENDPOINT,
+            "/".join(
+                [
+                    self.url,
+                    self.MODELS_ENDPOINT,
+                    str(model_id),
+                    self.VERSIONS_ENDPOINT,
+                    str(version_id),
+                    self.JOBS_ENDPOINT,
+                ]
             ),
             headers=headers,
             params=job_create.dict(),
@@ -995,13 +1011,15 @@ class VersionJobsClient(ApiClient):
         headers.update(self._get_auth_header())
 
         response = self.session.get(
-            os.path.join(
-                self.url,
-                self.MODELS_ENDPOINT,
-                str(model_id),
-                self.VERSIONS_ENDPOINT,
-                str(version_id),
-                self.JOBS_ENDPOINT,
+            "/".join(
+                [
+                    self.url,
+                    self.MODELS_ENDPOINT,
+                    str(model_id),
+                    self.VERSIONS_ENDPOINT,
+                    str(version_id),
+                    self.JOBS_ENDPOINT,
+                ]
             ),
             headers=headers,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "giza-cli"
-version = "0.9.0"
+version = "0.9.1"
 description = "CLI for interacting with Giza"
 authors = ["Gonzalo Mellizo-Soto <gonzalo@gizatech.xyz>"]
 readme = "README.md"


### PR DESCRIPTION
There was an issue with windows users due to using `os.path.join`, this function in unix like systems uses the `/` separator which its the same one used for urls but for windows systems the OS separator is `\` which in turn made the python request uses a non existent URL that returns a 404.

* Expected URL prior to fix: /api/v1%5Cmodels%5C247%5Cversions%5C6%5Cdeployments
* Actual URL prior to fix: /api/v1/models/247/versions/6/deployments

`%5C` its the url encoding for `\`

Now the path is joined using `"/".join([resources])` instead of `os.path.join` which is system dependant. 