### PR TITLE
Allow to update PARTIALLY_SUPPORTED versions

### DIFF
--- a/giza/client.py
+++ b/giza/client.py
@@ -672,7 +672,9 @@ class TranspileClient(ApiClient):
     Client to interact with `users` endpoint.
     """
 
-    TRANSPILE_ENDPOINT = "transpile"
+    MODELS_ENDPOINT = "models"
+    VERSIONS_ENDPOINT = "versions"
+    TRANSPILE_ENDPOINT = "transpilations"
 
     @auth
     def transpile(self, f: BinaryIO) -> Response:
@@ -696,6 +698,40 @@ class TranspileClient(ApiClient):
 
         response.raise_for_status()
         return response
+
+    @auth
+    def update_transpilation(self, model_id: int, version_id: int, f: BinaryIO) -> None:
+        """
+        Make a call to the API transpile endpoint with the model as a file.
+
+        Args:
+            f (BinaryIO): model to send for transpilation
+
+        Returns:
+            Response: raw response from the server with the transpiled model as a zip
+        """
+        headers = copy.deepcopy(self.default_headers)
+        headers.update(self._get_auth_header())
+
+        response = self.session.get(
+            f"{self.url}/{self.MODELS_ENDPOINT}/{model_id}/{self.VERSIONS_ENDPOINT}/{version_id}/transpilations/upload_url",
+            headers=headers,
+        )
+
+        self._echo_debug(str(response))
+        response.raise_for_status()
+        upload_url = response.json()["upload_url"]
+        response = self.session.put(
+            upload_url,
+            data=f,
+        )
+        response = self.session.put(
+            f"{self.url}/{self.MODELS_ENDPOINT}/{model_id}/{self.VERSIONS_ENDPOINT}/{version_id}/transpilations",
+            headers=headers,
+        )
+        self._echo_debug(str(response))
+
+        response.raise_for_status()
 
 
 class ModelsClient(ApiClient):

--- a/giza/commands/versions.py
+++ b/giza/commands/versions.py
@@ -1,6 +1,5 @@
 import sys
 import zipfile
-from io import BytesIO
 from typing import Dict, Optional
 
 import typer

--- a/giza/commands/versions.py
+++ b/giza/commands/versions.py
@@ -1,10 +1,10 @@
+import os
 import sys
 import zipfile
+from tempfile import TemporaryDirectory
 from typing import Dict, Optional
 
 import typer
-from pydantic import ValidationError
-from requests import HTTPError
 from rich import print_json
 
 from giza import API_HOST
@@ -12,9 +12,10 @@ from giza.client import VersionsClient
 from giza.frameworks import cairo, ezkl
 from giza.options import DEBUG_OPTION
 from giza.schemas.versions import Version, VersionList
-from giza.utils import echo, get_response_info
+from giza.utils import echo
 from giza.utils.enums import Framework, VersionStatus
-from giza.utils.misc import download_model_or_sierra
+from giza.utils.exception_handling import ExceptionHandler
+from giza.utils.misc import download_model_or_sierra, scarb_build, zip_folder
 
 app = typer.Typer()
 
@@ -31,34 +32,15 @@ app = typer.Typer()
 def get(
     model_id: int = typer.Option(None, help="The ID of the model"),
     version_id: int = typer.Option(None, help="The ID of the version"),
-    debug: Optional[bool] = DEBUG_OPTION,
+    debug: bool = DEBUG_OPTION,
 ) -> None:
     if any([model_id is None, version_id is None]):
         echo.error("⛔️Model ID and version ID are required⛔️")
         sys.exit(1)
     echo("Retrieving version information ✅ ")
-    try:
+    with ExceptionHandler(debug=debug):
         client = VersionsClient(API_HOST)
         version: Version = client.get(model_id, version_id)
-    except ValidationError as e:
-        echo.error("Version validation error")
-        echo.error("Review the provided information")
-        if debug:
-            raise e
-        echo.error(str(e))
-        sys.exit(1)
-    except HTTPError as e:
-        info = get_response_info(e.response)
-        echo.error("⛔️Could not retrieve version information")
-        echo.error(f"⛔️Detail -> {info.get('detail')}⛔️")
-        echo.error(f"⛔️Status code -> {info.get('status_code')}⛔️")
-        echo.error(f"⛔️Error message -> {info.get('content')}⛔️")
-        echo.error(
-            f"⛔️Request ID: Give this to an administrator to trace the error -> {info.get('request_id')}⛔️"
-        ) if info.get("request_id") else None
-        if debug:
-            raise e
-        sys.exit(1)
     print_json(version.json())
 
 
@@ -145,48 +127,48 @@ app.command(
 
 
 @app.command(
-    short_help="🔄 Update the description of a version.",
-    help="""🔄 Update the description of a version.
+    short_help="🔄 Update version data or a partially supported version",
+    help="""🔄 Update version data or a partially supported vers.
 
-    This command needs a model id and version id to update the description of a version.
+    This command aims to update version data or if a model is partially supported,
+    it will try to update the model to a fully supported version if a cairo model path is provided.
+
+    It will retrigger compilation of the model and if the model is fully supported, it will update the version to completed.
     """,
 )
 def update(
-    model_id: int = typer.Option(None, help="The ID of the model"),
-    version_id: int = typer.Option(None, help="The ID of the version"),
-    description: str = typer.Option(
-        None, "--description", "-d", help="New description for the version"
+    model_id: int = typer.Option(None, "--model-id", "-m", help="The ID of the model"),
+    version_id: int = typer.Option(
+        None, "--version-id", "-v", help="The ID of the version"
     ),
-    debug: Optional[bool] = DEBUG_OPTION,
+    model_path: str = typer.Option(
+        None, "--model-path", "-M", help="Path of the model to update"
+    ),
+    debug: bool = DEBUG_OPTION,
 ) -> None:
-    if any([model_id is None, version_id is None, description is None]):
-        echo.error(
-            "⛔️Model ID, version ID and description are required to update the version⛔️"
-        )
+    if any([model_id is None, version_id is None]):
+        echo.error("⛔️Model ID and version ID are required to update the version⛔️")
         sys.exit(1)
-    echo("Updating version description ✅ ")
-    try:
+    echo("Checking version ✅ ")
+    with ExceptionHandler(debug=debug):
         client = VersionsClient(API_HOST)
-        version = client.update(model_id, version_id, description)
-    except ValidationError as e:
-        echo.error("Version validation error")
-        echo.error("Review the provided information")
-        if debug:
-            raise e
-        echo.error(str(e))
-        sys.exit(1)
-    except HTTPError as e:
-        info = get_response_info(e.response)
-        echo.error("⛔️Could not update version")
-        echo.error(f"⛔️Detail -> {info.get('detail')}⛔️")
-        echo.error(f"⛔️Status code -> {info.get('status_code')}⛔️")
-        echo.error(f"⛔️Error message -> {info.get('content')}⛔️")
-        echo.error(
-            f"⛔️Request ID: Give this to an administrator to trace the error -> {info.get('request_id')}⛔️"
-        ) if info.get("request_id") else None
-        if debug:
-            raise e
-        sys.exit(1)
+        version = client.get(model_id, version_id)
+
+        if (
+            version.status != VersionStatus.PARTIALLY_SUPPORTED
+            and model_path is not None
+        ):
+            echo.error("⛔️Version has a different status than PARTIALLY_SUPPORTED⛔️")
+            sys.exit(1)
+        elif (
+            version.status == VersionStatus.PARTIALLY_SUPPORTED
+            and model_path is not None
+        ):
+            scarb_build(os.path.join(model_path, "inference"))
+            with TemporaryDirectory() as tmp_dir:
+                zip_path = zip_folder(model_path, tmp_dir)
+                version = client.upload_cairo(model_id, version_id, zip_path)
+        echo("Version updated ✅ ")
     print_json(version.json())
 
 
@@ -199,34 +181,15 @@ def update(
 )
 def list(
     model_id: int = typer.Option(None, help="The ID of the model"),
-    debug: Optional[bool] = DEBUG_OPTION,
+    debug: bool = DEBUG_OPTION,
 ) -> None:
     if model_id is None:
         echo.error("⛔️Model ID is required⛔️")
         sys.exit(1)
     echo("Listing versions for the model ✅ ")
-    try:
+    with ExceptionHandler(debug=debug):
         client = VersionsClient(API_HOST)
         versions: VersionList = client.list(model_id)
-    except ValidationError as e:
-        echo.error("Version validation error")
-        echo.error("Review the provided information")
-        if debug:
-            raise e
-        echo.error(str(e))
-        sys.exit(1)
-    except HTTPError as e:
-        info = get_response_info(e.response)
-        echo.error("⛔️Could not list versions for the model")
-        echo.error(f"⛔️Detail -> {info.get('detail')}⛔️")
-        echo.error(f"⛔️Status code -> {info.get('status_code')}⛔️")
-        echo.error(f"⛔️Error message -> {info.get('content')}⛔️")
-        echo.error(
-            f"⛔️Request ID: Give this to an administrator to trace the error -> {info.get('request_id')}⛔️"
-        ) if info.get("request_id") else None
-        if debug:
-            raise e
-        sys.exit(1)
     print_json(versions.json())
 
 
@@ -255,7 +218,7 @@ def download(
         "--download-sierra",
         help="Download the siera file is the modle is fully compatible. CAIRO only.",
     ),
-    debug: Optional[bool] = DEBUG_OPTION,
+    debug: bool = DEBUG_OPTION,
 ) -> None:
     """
     Retrieve information about the current user and print it as json to stdout.
@@ -264,7 +227,7 @@ def download(
         debug (Optional[bool], optional): Whether to add debug information, will show requests, extra logs and traceback if there is an Exception. Defaults to DEBUG_OPTION (False)
     """
 
-    try:
+    with ExceptionHandler(debug=debug):
         if any([model_id is None, version_id is None]):
             raise ValueError("⛔️Model ID and version ID are required⛔️")
 
@@ -290,23 +253,6 @@ def download(
                     "Something went wrong with the download", zip_error.args[0]
                 ) from None
             echo(f"{name} saved at: {output_path}")
-    except ValueError as e:
-        echo.error(e.args[0])
-        if debug:
-            raise e
-        sys.exit(1)
-    except HTTPError as e:
-        info = get_response_info(e.response)
-        echo.error("⛔️Error at download")
-        echo.error(f"⛔️Detail -> {info.get('detail')}⛔️")
-        echo.error(f"⛔️Status code -> {info.get('status_code')}⛔️")
-        echo.error(f"⛔️Error message -> {info.get('content')}⛔️")
-        echo.error(
-            f"⛔️Request ID: Give this to an administrator to trace the error -> {info.get('request_id')}⛔️"
-        ) if info.get("request_id") else None
-        if debug:
-            raise e
-        sys.exit(1)
 
 
 @app.command(
@@ -322,7 +268,7 @@ def download_original(
     output_path: str = typer.Option(
         "model.onnx", "--output-path", "-o", help="Path to output the ONNX model"
     ),
-    debug: Optional[bool] = DEBUG_OPTION,
+    debug: bool = DEBUG_OPTION,
 ) -> None:
     """
     Retrieve information about the current user and print it as json to stdout.
@@ -331,7 +277,7 @@ def download_original(
         debug (Optional[bool], optional): Whether to add debug information, will show requests, extra logs and traceback if there is an Exception. Defaults to DEBUG_OPTION (False)
     """
 
-    try:
+    with ExceptionHandler(debug=debug):
         if any([model_id is None, version_id is None]):
             raise ValueError("⛔️Model ID and version ID are required⛔️")
 
@@ -348,21 +294,3 @@ def download_original(
             f.write(onnx_model)
 
         echo(f"ONNX model saved at: {output_path}")
-
-    except ValueError as e:
-        echo.error(e.args[0])
-        if debug:
-            raise e
-        sys.exit(1)
-    except HTTPError as e:
-        info = get_response_info(e.response)
-        echo.error("⛔️Error at download")
-        echo.error(f"⛔️Detail -> {info.get('detail')}⛔️")
-        echo.error(f"⛔️Status code -> {info.get('status_code')}⛔️")
-        echo.error(f"⛔️Error message -> {info.get('content')}⛔️")
-        echo.error(
-            f"⛔️Request ID: Give this to an administrator to trace the error -> {info.get('request_id')}⛔️"
-        ) if info.get("request_id") else None
-        if debug:
-            raise e
-        sys.exit(1)

--- a/giza/commands/versions.py
+++ b/giza/commands/versions.py
@@ -1,7 +1,7 @@
 import sys
 import zipfile
 from io import BytesIO
-from typing import Optional
+from typing import Dict, Optional
 
 import typer
 from pydantic import ValidationError
@@ -15,6 +15,7 @@ from giza.options import DEBUG_OPTION
 from giza.schemas.versions import Version, VersionList
 from giza.utils import echo, get_response_info
 from giza.utils.enums import Framework, VersionStatus
+from giza.utils.misc import download_model_or_sierra
 
 app = typer.Typer()
 
@@ -84,6 +85,16 @@ def transpile(
         "-i",
         help="The input data to use for the transpilation",
     ),
+    download_model: bool = typer.Option(
+        True,
+        "--download-model",
+        help="Download the transpiled model after the transpilation is completed. CAIRO only.",
+    ),
+    download_sierra: bool = typer.Option(
+        False,
+        "--download-sierra",
+        help="Download the siera file is the modle is fully compatible. CAIRO only.",
+    ),
     debug: Optional[bool] = DEBUG_OPTION,
 ) -> None:
     if framework == Framework.CAIRO:
@@ -93,6 +104,8 @@ def transpile(
             desc=desc,
             model_desc=model_desc,
             output_path=output_path,
+            download_model=download_model,
+            download_sierra=download_sierra,
             debug=debug,
         )
     elif framework == Framework.EZKL:
@@ -233,6 +246,16 @@ def download(
     output_path: str = typer.Option(
         "cairo_model", "--output-path", "-o", help="Path to output the cairo model"
     ),
+    download_model: bool = typer.Option(
+        False,
+        "--download-model",
+        help="Download the transpiled model after the transpilation is completed. CAIRO only.",
+    ),
+    download_sierra: bool = typer.Option(
+        False,
+        "--download-sierra",
+        help="Download the siera file is the modle is fully compatible. CAIRO only.",
+    ),
     debug: Optional[bool] = DEBUG_OPTION,
 ) -> None:
     """
@@ -253,18 +276,21 @@ def download(
             raise ValueError(f"Model version status is not completed {version.status}")
 
         echo("Transpilation is ready, downloading! ✅")
-        cairo_model = client.download(model_id, version.version)
+        downloads: Dict[str, bytes] = client.download(
+            model_id,
+            version.version,
+            {"download_model": download_model, "download_sierra": download_sierra},
+        )
 
-        try:
-            zip_file = zipfile.ZipFile(BytesIO(cairo_model))
-        except zipfile.BadZipFile as zip_error:
-            raise ValueError(
-                "Something went wrong with the transpiled file", zip_error.args[0]
-            ) from None
-
-        zip_file.extractall(output_path)
-        echo(f"Transpilation saved at: {output_path}")
-
+        for name, content in downloads.items():
+            try:
+                echo(f"Downloading {name} ✅")
+                download_model_or_sierra(content, output_path, name)
+            except zipfile.BadZipFile as zip_error:
+                raise ValueError(
+                    "Something went wrong with the transpiled file", zip_error.args[0]
+                ) from None
+            echo(f"{name} saved at: {output_path}")
     except ValueError as e:
         echo.error(e.args[0])
         if debug:

--- a/giza/commands/versions.py
+++ b/giza/commands/versions.py
@@ -274,7 +274,7 @@ def download(
         if version.status != VersionStatus.COMPLETED:
             raise ValueError(f"Model version status is not completed {version.status}")
 
-        echo("Transpilation is ready, downloading! ✅")
+        echo("Data is ready, downloading! ✅")
         downloads: Dict[str, bytes] = client.download(
             model_id,
             version.version,
@@ -287,7 +287,7 @@ def download(
                 download_model_or_sierra(content, output_path, name)
             except zipfile.BadZipFile as zip_error:
                 raise ValueError(
-                    "Something went wrong with the transpiled file", zip_error.args[0]
+                    "Something went wrong with the download", zip_error.args[0]
                 ) from None
             echo(f"{name} saved at: {output_path}")
     except ValueError as e:

--- a/giza/exceptions.py
+++ b/giza/exceptions.py
@@ -1,2 +1,10 @@
 class PasswordError(Exception):
     pass
+
+
+class ScarbBuildError(Exception):
+    pass
+
+
+class ScarbNotFound(Exception):
+    pass

--- a/giza/frameworks/cairo.py
+++ b/giza/frameworks/cairo.py
@@ -2,7 +2,6 @@ import json
 import sys
 import time
 import zipfile
-from io import BytesIO
 from pathlib import Path
 from typing import Optional
 

--- a/giza/frameworks/cairo.py
+++ b/giza/frameworks/cairo.py
@@ -37,6 +37,7 @@ from giza.utils.enums import (
     ServiceSize,
     VersionStatus,
 )
+from giza.utils.misc import download_model_or_sierra
 
 app = typer.Typer()
 
@@ -212,6 +213,8 @@ def transpile(
     desc: str,
     model_desc: str,
     output_path: str,
+    download_model: bool,
+    download_sierra: bool,
     debug: Optional[bool],
 ) -> None:
     """
@@ -232,6 +235,8 @@ def transpile(
         desc (int, optional): Description of the version. Defaults to None.
         model_desc (int, optional): Description of the Model to create if model_id is not provided. Defaults to None.
         output_path (str, optional): The path where the cairo model will be saved. Defaults to "cairo_model".
+        download_model (bool): A flag used to determine whether to download the model or not.
+        download_sierra (bool): A flag used to determine whether to download the sierra or not.
         debug (bool, optional): A flag used to determine whether to raise exceptions or not. Defaults to DEBUG_OPTION.
 
     Raises:
@@ -351,19 +356,23 @@ def transpile(
             raise e
         sys.exit(1)
 
-    echo("Transpilation recieved! ✅")
     try:
-        cairo_model = client.download(model.id, version.version)
-        zip_file = zipfile.ZipFile(BytesIO(cairo_model))
+        if download_model or download_sierra:
+            params = {
+                "download_model": download_model,
+                "download_sierra": download_sierra,
+            }
+            downloads = client.download(model.id, version.version, params)
+            for name, content in downloads.items():
+                echo(f"Downloading {name} ✅")
+                download_model_or_sierra(content, output_path, name)
+                echo(f"{name} saved at: {output_path}")
     except zipfile.BadZipFile as zip_error:
         echo.error("Something went wrong with the transpiled file")
         echo.error(f"Error -> {zip_error.args[0]}")
         if debug:
             raise zip_error
         sys.exit(1)
-
-    zip_file.extractall(output_path)
-    echo(f"Transpilation saved at: {output_path}")
 
 
 def verify(

--- a/giza/utils/exception_handling.py
+++ b/giza/utils/exception_handling.py
@@ -1,0 +1,69 @@
+import sys
+
+from pydantic import ValidationError
+from requests import HTTPError
+
+from giza.exceptions import ScarbBuildError, ScarbNotFound
+from giza.utils import echo, get_response_info
+
+
+class ExceptionHandler:
+    """
+    Context manager to handle exceptions in the CLI.
+
+    The main purpose of this class is to handle common exceptions in the CLI and
+    provide a consistent way to handle them.
+
+    The CLI commands should be wrapped with this context manager to handle exceptions
+    and provide a consistent way to handle them.
+
+    Example:
+    ```python
+    with ExceptionHandler():
+        # Your command code here
+        client = Client()
+        client.get() # This will raise an exception if something goes wrong but will be handled in __exit__
+    ```
+
+    """
+
+    def __init__(self, debug: bool = False) -> None:
+        if debug is None:
+            debug = False
+        self.debug = debug
+
+    def handle_exit(self):
+        if self.debug:
+            return False
+        sys.exit(1)
+
+    def __enter__(self):
+        # Set up resources here
+        pass
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        error = None
+        if exc_type in [ScarbBuildError, ScarbNotFound]:
+            error = True
+            echo.error("⛔️Error building the scarb model⛔️")
+            echo.error("⛔️Version could not be updated⛔️")
+            echo.error("Check scarb documentation https://docs.swmansion.com/scarb/")
+        elif exc_type == ValidationError:
+            error = True
+            echo.error("Resource validation error")
+            echo.error("Review the provided information")
+        elif exc_type == HTTPError:
+            error = True
+            info = get_response_info(exc_value.response)
+            echo.error("⛔️Could not perform the action on the resource⛔️")
+            echo.error(f"⛔️Detail -> {info.get('detail')}⛔️")
+            echo.error(f"⛔️Status code -> {info.get('status_code')}⛔️")
+            echo.error(f"⛔️Error message -> {info.get('content')}⛔️")
+            echo.error(
+                f"⛔️Request ID: Give this to an administrator to trace the error -> {info.get('request_id')}⛔️"
+            ) if info.get("request_id") else None
+        elif isinstance(exc_value, Exception):
+            error = True
+            echo.error(f"⛔️An error occurred: {exc_value}⛔️")
+        if error:
+            return self.handle_exit()

--- a/giza/utils/misc.py
+++ b/giza/utils/misc.py
@@ -2,7 +2,7 @@ import os
 import re
 import zipfile
 from io import BytesIO
-from typing import Dict, Optional
+from typing import Optional
 
 from giza.exceptions import PasswordError
 

--- a/giza/utils/misc.py
+++ b/giza/utils/misc.py
@@ -1,4 +1,8 @@
+import os
 import re
+import zipfile
+from io import BytesIO
+from typing import Dict, Optional
 
 from giza.exceptions import PasswordError
 
@@ -18,3 +22,26 @@ def _check_password_strength(password: str) -> None:
         raise PasswordError(
             "Password must be at least 8 characters long, contain at least one uppercase letter, one lowercase letter and one number."
         )
+
+
+def download_model_or_sierra(
+    content: bytes, output_path: str, name: Optional[str] = None
+):
+    """
+    Download the model or sierra file.
+
+    Args:
+        content (bytes): file content
+        output_path (str): path to save the file
+        name (str): file name. Defaults to None.
+    """
+    f = BytesIO(content)
+    is_zip = zipfile.is_zipfile(f)
+    if not is_zip and name is not None:
+        if not os.path.exists(output_path):
+            os.makedirs(output_path)
+        with open(os.path.join(output_path, name), "wb") as file_:
+            file_.write(content)
+    else:
+        zip_file = zipfile.ZipFile(f)
+        zip_file.extractall(output_path)

--- a/tests/commands/test_versions.py
+++ b/tests/commands/test_versions.py
@@ -63,7 +63,7 @@ def test_versions_get_http_error():
         )
 
     assert result.exit_code == 1
-    assert "Could not retrieve version information" in result.stdout
+    assert "Could not perform the action on the resource" in result.stdout
 
 
 # Test version retrieval with invalid version id
@@ -77,7 +77,7 @@ def test_versions_get_invalid_id():
         )
 
     assert result.exit_code == 1
-    assert "Version validation error" in result.stdout
+    assert "Resource validation error" in result.stdout
 
 
 # Test successful version listing
@@ -112,7 +112,7 @@ def test_versions_list_server_error():
         )
 
     assert result.exit_code == 1
-    assert "Could not list versions for the model" in result.stdout
+    assert "Could not perform the action on the resource" in result.stdout
 
 
 # Test successful version transpilation
@@ -306,7 +306,7 @@ def test_versions_download_server_error():
         )
 
     assert result.exit_code == 1
-    assert "Error at download" in result.stdout
+    assert "Could not perform the action on the resource" in result.stdout
 
 
 # Test version download but a file, imitating a sierra file
@@ -368,33 +368,17 @@ def test_versions_update_successful():
         version=1,
         size=1,
         description="updated_description",
-        status=VersionStatus.COMPLETED,
+        status=VersionStatus.PARTIALLY_SUPPORTED,
         created_date="2021-08-31T15:00:00.000000",
         last_update="2021-08-31T15:00:00.000000",
     )
+    updated_version = version.copy()
+    updated_version.status = VersionStatus.COMPLETED
 
-    with patch.object(VersionsClient, "update", return_value=version):
-        result = invoke_cli_runner(
-            [
-                "versions",
-                "update",
-                "--model-id",
-                "1",
-                "--version-id",
-                "1",
-                "--description",
-                "updated_description",
-            ]
-        )
-
-    assert "Updating version description" in result.stdout
-    assert result.exit_code == 0
-    assert "updated_description" in result.stdout
-
-
-def test_versions_update_server_error():
-    with patch.object(VersionsClient, "update", side_effect=HTTPError), patch(
-        "giza.commands.versions.get_response_info", return_value={}
+    with patch.object(VersionsClient, "get", return_value=version), patch.object(
+        VersionsClient, "upload_cairo", return_value=updated_version
+    ), patch("giza.commands.versions.scarb_build"), patch(
+        "giza.commands.versions.zip_folder"
     ):
         result = invoke_cli_runner(
             [
@@ -404,13 +388,49 @@ def test_versions_update_server_error():
                 "1",
                 "--version-id",
                 "1",
-                "--description",
-                "updated_description",
+                "--model-path",
+                "path",
+            ]
+        )
+
+    assert "Checking version" in result.stdout
+    assert result.exit_code == 0
+    assert "Version updated" in result.stdout
+
+
+def test_versions_update_server_error():
+    version = Version(
+        version=1,
+        size=1,
+        description="updated_description",
+        status=VersionStatus.PARTIALLY_SUPPORTED,
+        created_date="2021-08-31T15:00:00.000000",
+        last_update="2021-08-31T15:00:00.000000",
+    )
+    with patch.object(
+        VersionsClient, "upload_cairo", side_effect=HTTPError
+    ), patch.object(VersionsClient, "get", return_value=version), patch(
+        "giza.commands.versions.get_response_info", return_value={}
+    ), patch(
+        "giza.commands.versions.scarb_build"
+    ), patch(
+        "giza.commands.versions.zip_folder"
+    ):
+        result = invoke_cli_runner(
+            [
+                "versions",
+                "update",
+                "--model-id",
+                "1",
+                "--version-id",
+                "1",
+                "--model-path",
+                "path",
             ],
             expected_error=True,
         )
 
-    assert "Could not update version" in result.stdout
+    assert "Could not perform the action on the resource" in result.stdout
     assert result.exit_code == 1
 
 
@@ -422,14 +442,9 @@ def test_versions_update_missing_ids():
             [
                 "versions",
                 "update",
-                "--description",
-                "updated_description",
             ],
             expected_error=True,
         )
 
-    assert (
-        "Model ID, version ID and description are required to update the version"
-        in result.stdout
-    )
+    assert "Model ID and version ID are required to update the version" in result.stdout
     assert result.exit_code == 1

--- a/tests/commands/test_versions.py
+++ b/tests/commands/test_versions.py
@@ -55,7 +55,7 @@ def test_versions_get():
 # Test version retrieval that throws an HTTPError
 def test_versions_get_http_error():
     with patch.object(VersionsClient, "get", side_effect=HTTPError), patch(
-        "giza.commands.versions.get_response_info", return_value={}
+        "giza.utils.exception_handling.get_response_info", return_value={}
     ):
         result = invoke_cli_runner(
             ["versions", "get", "--model-id", "1", "--version-id", "1"],
@@ -70,7 +70,7 @@ def test_versions_get_http_error():
 def test_versions_get_invalid_id():
     with patch.object(
         VersionsClient, "get", side_effect=ValidationError(errors=[], model=Version)
-    ), patch("giza.commands.versions.get_response_info", return_value={}):
+    ), patch("giza.utils.exception_handling.get_response_info", return_value={}):
         result = invoke_cli_runner(
             ["versions", "get", "--model-id", "1", "--version-id", "1"],
             expected_error=True,
@@ -105,7 +105,7 @@ def test_versions_list():
 # Test version listing with server error
 def test_versions_list_server_error():
     with patch.object(VersionsClient, "list", side_effect=HTTPError), patch(
-        "giza.commands.versions.get_response_info", return_value={}
+        "giza.utils.exception_handling.get_response_info", return_value={}
     ):
         result = invoke_cli_runner(
             ["versions", "list", "--model-id", "1"], expected_error=True
@@ -177,7 +177,7 @@ def test_versions_transpile_successful(tmpdir):
 def test_versions_transpile_http_error(tmpdir):
     with patch(
         "giza.frameworks.cairo.ModelsClient.get_by_name", side_effect=HTTPError
-    ), patch("giza.frameworks.cairo.get_response_info", return_value={}), patch(
+    ), patch("giza.utils.exception_handling.get_response_info", return_value={}), patch(
         "giza.frameworks.cairo.Path"
     ), patch.object(
         VersionsClient, "_load_credentials_file"
@@ -289,7 +289,7 @@ def test_versions_download_successful(tmpdir):
 # Test version download with server error
 def test_versions_download_server_error():
     with patch.object(VersionsClient, "get", side_effect=HTTPError), patch(
-        "giza.commands.versions.get_response_info", return_value={}
+        "giza.utils.exception_handling.get_response_info", return_value={}
     ):
         result = invoke_cli_runner(
             [
@@ -347,7 +347,7 @@ def test_versions_download_file(tmpdir):
 # Test version download with missing model_id and version_id
 def test_versions_download_missing_ids():
     with patch.object(VersionsClient, "get", side_effect=HTTPError), patch(
-        "giza.commands.versions.get_response_info", return_value={}
+        "giza.utils.exception_handling.get_response_info", return_value={}
     ):
         result = invoke_cli_runner(
             [
@@ -379,6 +379,8 @@ def test_versions_update_successful():
         VersionsClient, "upload_cairo", return_value=updated_version
     ), patch("giza.commands.versions.scarb_build"), patch(
         "giza.commands.versions.zip_folder"
+    ), patch(
+        "giza.commands.versions.update_sierra"
     ):
         result = invoke_cli_runner(
             [
@@ -410,11 +412,13 @@ def test_versions_update_server_error():
     with patch.object(
         VersionsClient, "upload_cairo", side_effect=HTTPError
     ), patch.object(VersionsClient, "get", return_value=version), patch(
-        "giza.commands.versions.get_response_info", return_value={}
+        "giza.utils.exception_handling.get_response_info", return_value={}
     ), patch(
         "giza.commands.versions.scarb_build"
     ), patch(
         "giza.commands.versions.zip_folder"
+    ), patch(
+        "giza.commands.versions.update_sierra",
     ):
         result = invoke_cli_runner(
             [
@@ -436,7 +440,7 @@ def test_versions_update_server_error():
 
 def test_versions_update_missing_ids():
     with patch.object(VersionsClient, "update", side_effect=HTTPError), patch(
-        "giza.commands.versions.get_response_info", return_value={}
+        "giza.utils.exception_handling.get_response_info", return_value={}
     ):
         result = invoke_cli_runner(
             [


### PR DESCRIPTION
Now a version will be allowed to update the cairo code if it compiles successfully:

* Check that the version is PARTIALLY_SUPPORTED if any other status the version is NOT allowed to update
* Check that scarb its installed
* Try to compile the model, if it compiles the cairo code and sierra file are uploaded and updated in Giza
* Updated tests
* Added `ExceptionHandler` to handle common CLI errors like `HTTPError` or `ValidationError`