### PR TITLE
Replace textual sierra with sierra JSON

### DIFF
--- a/docs/frameworks/cairo/deploy.md
+++ b/docs/frameworks/cairo/deploy.md
@@ -5,7 +5,7 @@ To deploy a model, you must first have a version of that model. If you have not 
 To create a new service, users can employ the `deploy` command. This command facilitates the deployment of a machine learning service ready to accept predictions at the `/cairo_run` endpoint, providing a straightforward method for deploying and using machine learning capabilities that can easily be consumed as and API endpoint.
 
 ```
-> giza endpoints deploy --model-id 1 --version-id 1 model.sierra
+> giza endpoints deploy --model-id 1 --version-id 1 model.sierra.json
 ▰▰▰▰▰▱▱ Creating endpoint!
 [giza][2024-02-07 12:31:02.498] Endpoint is successful ✅
 [giza][2024-02-07 12:31:02.501] Endpoint created with id -> 1 ✅

--- a/docs/frameworks/cairo/transpile.md
+++ b/docs/frameworks/cairo/transpile.md
@@ -38,7 +38,7 @@ my_awesome_model
 
 When we transpile a model we have two possibilities: a fully compatible model and a partially compatible one.
 
-A model is fully compatible when all the operators that the model uses are supported by the Transpiler and Orion, if this happens the model is compiled after transpilation and we save the .sierra file on behalf of the user to use later for deployment ([endpoint docs](../../resources/endpoints.md)). This will be shown in the output of the transpile command:
+A model is fully compatible when all the operators that the model uses are supported by the Transpiler and Orion, if this happens the model is compiled after transpilation and we save the .sierra.json file on behalf of the user to use later for deployment ([endpoint docs](../../resources/endpoints.md)). This will be shown in the output of the transpile command:
 
 {% code overflow="wrap" %}
 ```

--- a/docs/resources/endpoints.md
+++ b/docs/resources/endpoints.md
@@ -9,7 +9,7 @@ To deploy a model, you must first have a version of that model. If you have not 
 To create a new service, users can employ the `deploy` command. This command facilitates the deployment of a machine learning service ready to accept predictions at the `/cairo_run` endpoint, providing a straightforward method for deploying and utilizing machine learning capabilities.
 
 ```console
-> giza endpoints deploy --model-id 1 --version-id 1 model.sierra
+> giza endpoints deploy --model-id 1 --version-id 1 model.sierra.json
 ▰▰▰▰▰▱▱ Creating endpoint!
 [giza][2024-02-07 12:31:02.498] Endpoint is successful ✅
 [giza][2024-02-07 12:31:02.501] Endpoint created with id -> 1 ✅

--- a/giza/client.py
+++ b/giza/client.py
@@ -1367,7 +1367,7 @@ class VersionsClient(ApiClient):
 
             sierra_response.raise_for_status()
             self._echo_debug(str(sierra_response))
-            downloads["inference.sierra"] = sierra_response.content
+            downloads["inference.sierra.json"] = sierra_response.content
 
         return downloads
 

--- a/giza/commands/versions.py
+++ b/giza/commands/versions.py
@@ -23,7 +23,7 @@ app = typer.Typer()
 
 def update_sierra(model_id: int, version_id: int, model_path: str):
     sierra_path = glob.glob(
-        os.path.join(model_path, "inference", "**/*.sierra"), recursive=True
+        os.path.join(model_path, "inference", "**/*.sierra.json"), recursive=True
     )[0]
     with open(sierra_path, "rb") as f:
         TranspileClient(API_HOST).update_transpilation(model_id, version_id, f)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "giza-cli"
-version = "0.14.1"
+version = "0.14.2"
 description = "CLI for interacting with Giza"
 authors = ["Gonzalo Mellizo-Soto <gonzalo@gizatech.xyz>"]
 readme = "README.md"


### PR DESCRIPTION
Replaced textual Sierra with JSON Sierra. Textual Sierra has some bugs, and is for debugging purposes, JSON version is more stable and don't have the [bugs](https://github.com/lambdaclass/cairo-vm/issues/1688) we encountered with tree based models.

@Gonmeso please let's check if I forgot something in giza-cli for this purpose